### PR TITLE
:bug: Fix SSH key handling in deploy workflow

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -81,7 +81,7 @@ jobs:
           pulumi config set --secret backupDataScript "$(cat ./bin/backupData.js)"
           pulumi config set --secret uploadToS3Script "$(cat ./bin/uploadToS3.js)"
           pulumi config set --secret restoreBackupScript "$(cat ./bin/restoreBackup.js)"
-          cat -- ${{ secrets.SSH_PRIVATE_KEY }} | pulumi config set sshPrivateKey --secret
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" | tr -d '\r' | pulumi config set sshPrivateKey --secret
 
       - name: Deploy infrastructure
         uses: pulumi/actions@v5


### PR DESCRIPTION
Address issue where SSH key contains unwanted carriage returns
(trailing '\r'), preventing proper configuration using Pulumi.
Switch from `cat` to `echo` in conjunction with `tr -d '\r'`
to clean the SSH key before setting it as a secret.