### PR TITLE
✨ chore: update Pulumi config & refactor asset names

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -46,10 +46,10 @@ jobs:
       - name: Configure Pulumi
         run: |
           pulumi stack select codigo/${{ github.event.client_payload.name }}/prod
-          pulumi config set aws:region ${{ secrets.AWS_REGION }}
+          pulumi config set aws:region ${{ vars.AWS_REGION }}
           pulumi config set --secret hcloud:token ${{ secrets.HETZNER_CLOUD_KEY }}
           pulumi config set appName ${{ github.event.client_payload.name }}
-          
+
           # Set configs from secrets
           pulumi config set awsAccessKeyId --secret "${{ secrets.AWS_ACCESS_KEY_ID }}"
           pulumi config set awsSecretAccessKey --secret "${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/infra/serverCopyMauAppFiles.ts
+++ b/infra/serverCopyMauAppFiles.ts
@@ -26,7 +26,7 @@ export function copyMauAppDataFilesToServer(server: pulumi.Output<Server>, publi
   // SCP commands to copy docker compose tooling string to the server
   const scpDockerComposeTooling = new command.remote.CopyToRemote("scp docker compose tooling", {
     connection,
-    source: new pulumi.asset.StringAsset(`docker-compose.mau-app.yaml`),
+    source: new pulumi.asset.StringAsset(`docker_compose_mau_app`),
     remotePath: "~/docker-compose.mau-app.yaml",
   }, { dependsOn: createMauAppFolders });
 

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -7,9 +7,9 @@ export function copyToolingDataFilesToServer(server: pulumi.Output<Server>, publ
   // Define the server details and credentials
   const config = new pulumi.Config();
   const sshPrivateKey = config.requireSecret("sshPrivateKey");
-  const dozzleUsers = config.require("dozzleUsers");
-  const shepherdConfig = config.require("shepherdConfig");
-  const caddyFile = config.require("caddyfile");
+  const dozzleUsers = config.require("users");
+  const shepherdConfig = config.require("shepherd_config");
+  const caddyFile = config.require("Caddyfile");
 
   const backupDataScript = config.require("backupDataScript");
   const uploadToS3Script = config.require("uploadToS3Script");
@@ -35,7 +35,7 @@ export function copyToolingDataFilesToServer(server: pulumi.Output<Server>, publ
   // SCP commands to copy docker compose tooling string to the server
   const scpDockerComposeTooling = new command.remote.CopyToRemote("scp docker compose tooling", {
     connection,
-    source: new pulumi.asset.StringAsset(`docker-compose.tooling.yaml`),
+    source: new pulumi.asset.StringAsset(`docker_compose_tooling`),
     remotePath: "~/docker-compose.tooling.yaml",
   }, { dependsOn: createToolingFolders });
 


### PR DESCRIPTION
Update AWS region config in deploy-infrastructure.yaml 
to use vars instead of secrets. Standardize asset 
naming patterns in server copy scripts to improve 
consistency. Adjust config variable names for better 
clarity in serverCopyToolingFiles.ts.