### PR TITLE
🎨 refactor: Update IAM S3 resource ARNs and remove Pulumi config

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -1,3 +1,0 @@
-config:
-  pulumi:tags:
-    pulumi:template: https://www.pulumi.com/ai/api/project/f8aaaf37-02d8-45fe-b5d8-b6d9af5b685a.zip

--- a/infra/iam.ts
+++ b/infra/iam.ts
@@ -29,8 +29,10 @@ export function createIAMResources() {
           "s3:DeleteObject",
         ],
         Resource: [
-          pulumi.interpolate`arn:aws:s3:::${appName}-bucket/*`,
-          pulumi.interpolate`arn:aws:s3:::tooling-bucket/*`,
+          `arn:aws:s3:::${appName}-bucket`,
+          `arn:aws:s3:::${appName}-bucket/*`,
+          "arn:aws:s3:::tooling-bucket",
+          "arn:aws:s3:::tooling-bucket/*",
         ],
       },
     ],


### PR DESCRIPTION
Remove unused Pulumi.prod.yaml configuration file to streamline
infrastructure setup. Update IAM role policies to include resource
specific S3 ARNs for both app and tooling buckets. This ensures
fine-grained access control and prevents potential permission
issues.