### PR TITLE
💾 refactor: update Cloudflare config key naming

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -78,9 +78,9 @@ jobs:
           pulumi config set backupDir ${{ vars.BACKUP_DIR }}
 
           # Set Cloudflare tunnel configurations
-          pulumi config set cloudflare:accountId ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          pulumi config set cloudflare:codigoZoneId ${{ secrets.CLOUDFLARE_CODIGO_ZONE_ID }}
-          pulumi config set cloudflare:maumercadoZoneId ${{ secrets.CLOUDFLARE_MAUMERCADO_ZONE_ID }}
+          pulumi config set cloudflareAccountId --secret "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
+          pulumi config set cloudflareCodigoZoneId --secret "${{ secrets.CLOUDFLARE_CODIGO_ZONE_ID }}"
+          pulumi config set cloudflareMaumercadoZoneId --secret "${{ secrets.CLOUDFLARE_MAUMERCADO_ZONE_ID }}"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}

--- a/infra/cloudflare.ts
+++ b/infra/cloudflare.ts
@@ -3,9 +3,9 @@ import * as cloudflare from "@pulumi/cloudflare";
 import * as random from "@pulumi/random";
 
 const config = new pulumi.Config();
-const accountId = config.require("cloudflare:accountId");
-const maumercadoZoneId = config.require("cloudflare:maumercadoZoneId");
-const codigoZoneId = config.require("cloudflare:codigoZoneId");
+const accountId = config.require("cloudflareAccountId");
+const maumercadoZoneId = config.require("cloudflareMaumercadoZoneId");
+const codigoZoneId = config.require("cloudflareCodigoZoneId");
 export function createCloudflareTunnels(serverIp: string) {
     // Create a random password for the maumercado tunnel secret
     const maumercadoTunnelSecret = new random.RandomPassword("maumercado-tunnel-secret", {


### PR DESCRIPTION
Update Cloudflare configuration keys to remove colons and adhere
to the new naming convention. This aligns the configuration naming
with the secrets in the GitHub workflow, ensuring consistency and
readability.