### PR TITLE
:lock: chore: Add Cloudflare API token to Pulumi config

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -81,6 +81,7 @@ jobs:
           pulumi config set cloudflareAccountId --secret "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
           pulumi config set cloudflareCodigoZoneId --secret "${{ secrets.CLOUDFLARE_CODIGO_ZONE_ID }}"
           pulumi config set cloudflareMaumercadoZoneId --secret "${{ secrets.CLOUDFLARE_MAUMERCADO_ZONE_ID }}"
+          pulumi config set cloudflare:apiToken --secret "${{ secrets.CLOUDFLARE_API_TOKEN }}"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}


### PR DESCRIPTION
Add Cloudflare API token to Pulumi config in GitHub
Actions workflow to enable authenticated requests to
Cloudflare API. This change enhances security by
utilizing the API token for operations.