### PR TITLE
🔧 Remove redundant SSH key and agent setup steps

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -48,9 +48,6 @@ jobs:
           echo "${{ secrets.SSH_PUBLIC_KEY }}" > ~/.ssh/id_rsa.pub
           chmod 600 ~/.ssh/id_rsa
           chmod 644 ~/.ssh/id_rsa.pub
-          ssh-keyscan -H ${{ secrets.SERVER_IP }} >> ~/.ssh/known_hosts
-          eval "$(ssh-agent -s)"
-          ssh-add ~/.ssh/id_rsa
 
       - name: Setup Pulumi
         uses: pulumi/actions@v5


### PR DESCRIPTION
Remove unnecessary SSH key scanning, ssh-agent evaluation, and
ssh-add commands from deploy-infrastructure.yaml to simplify
workflow and avoid potential security risks.