### PR TITLE
:lock: Validate SSH Public Key Format in Hetzner Server Script

### DIFF
--- a/infra/hetznerServer.ts
+++ b/infra/hetznerServer.ts
@@ -5,9 +5,20 @@ export function createHetznerServer() {
   const config = new pulumi.Config();
   const appName = config.require("appName");
 
+  // Get the public key from the configuration
+  let publicKey = config.require("sshPublicKey");
+
+  // Trim any leading or trailing whitespace
+  publicKey = publicKey.trim();
+
+  // Ensure the key type is specified
+  if (!publicKey.startsWith("ssh-rsa") && !publicKey.startsWith("ssh-ed25519") && !publicKey.startsWith("ecdsa-sha2-nistp")) {
+    throw new Error("Invalid SSH key format. The key should start with ssh-rsa, ssh-ed25519, or ecdsa-sha2-nistp.");
+  }
+
   const sshKey = new hcloud.SshKey("deploy-key", {
     name: `${appName}-deploy-key`,
-    publicKey: config.require("sshPublicKey"),
+    publicKey: publicKey,
   });
 
   const server = new hcloud.Server(`${appName}-server`, {


### PR DESCRIPTION
Adds validation for SSH public key format to ensure it starts with
"ssh-rsa", "ssh-ed25519", or "ecdsa-sha2-nistp". Trims any leading
or trailing whitespace from the public key to avoid errors.