### PR TITLE
🔧 infra: Update Hetzner server configuration

### DIFF
--- a/infra/hetznerServer.ts
+++ b/infra/hetznerServer.ts
@@ -32,10 +32,10 @@ export function createHetznerServer() {
 
   const server = new hcloud.Server(`${appName}-server`, {
     name: `${appName}-server`,
-    serverType: "cx11",
+    serverType: "cpx11",
     image: "ubuntu-24.04",
     sshKeys: [sshKey.id],
-    location: "ash",
+    location: "hil"
   });
 
   return {


### PR DESCRIPTION
Change server type to "cpx11" and location to "hil" in
createHetznerServer function for better performance and
geographical accuracy.