### PR TITLE
:lock: Decode SSH keys from base64 and update server config

### DIFF
--- a/infra/deployDockerStacks.ts
+++ b/infra/deployDockerStacks.ts
@@ -7,7 +7,12 @@ export function deployDockerStacks(
   publicIp: pulumi.Output<string>,
 ) {
   const config = new pulumi.Config();
-  const sshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const sshPrivateKey = pulumi
+    .all([encodedSshPrivateKey])
+    .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
 
   // SSH command to deploy docker stacks
   const deployDockerStacks = new command.remote.Command("deployDockerStacks", {

--- a/infra/hetznerServer.ts
+++ b/infra/hetznerServer.ts
@@ -40,13 +40,17 @@ export function createHetznerServer() {
     publicKey: publicKey,
   });
 
-  const server = new hcloud.Server(`${appName}-server`, {
-    name: `${appName}-server`,
-    serverType: "cpx11",
-    image: "ubuntu-24.04",
-    sshKeys: [sshKey.id],
-    location: "hil",
-  });
+  const server = new hcloud.Server(
+    `${appName}-server`,
+    {
+      name: `${appName}-server`,
+      serverType: "cpx11",
+      image: "ubuntu-24.04",
+      sshKeys: [sshKey.id],
+      location: "hil",
+    },
+    { dependsOn: sshKey },
+  );
 
   return {
     server: pulumi.output(server as hcloud.Server),

--- a/infra/serverConfig.ts
+++ b/infra/serverConfig.ts
@@ -7,12 +7,17 @@ export function configureServer(
   publicIp: pulumi.Output<string>,
 ) {
   const config = new pulumi.Config();
-  const sshPrivateKey = config.requireSecret("sshPrivateKey");
+  const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
   const encodedSshPublicKey = config.requireSecret("sshPublicKey");
 
   // Decode the base64-encoded public key
   const sshPublicKey = pulumi
     .all([encodedSshPublicKey])
+    .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
+
+  // Decode the base64-encoded private key
+  const sshPrivateKey = pulumi
+    .all([encodedSshPrivateKey])
     .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
 
   // Debug logging

--- a/infra/serverCopyMauAppFiles.ts
+++ b/infra/serverCopyMauAppFiles.ts
@@ -8,7 +8,11 @@ export function copyMauAppDataFilesToServer(
 ) {
   // Define the server details and credentials
   const config = new pulumi.Config();
-  const sshPrivateKey = config.requireSecret("sshPrivateKey");
+  const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const sshPrivateKey = pulumi
+    .all([encodedSshPrivateKey])
+    .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
 
   const connection = {
     host: publicIp,

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -8,7 +8,6 @@ export function copyToolingDataFilesToServer(
 ) {
   // Define the server details and credentials
   const config = new pulumi.Config();
-  const sshPrivateKey = config.requireSecret("sshPrivateKey");
   const dozzleUsers = config.require("users");
   const shepherdConfig = config.require("shepherd_config");
   const caddyFile = config.require("Caddyfile");
@@ -16,6 +15,12 @@ export function copyToolingDataFilesToServer(
   const backupDataScript = config.require("backupDataScript");
   const uploadToS3Script = config.require("uploadToS3Script");
   const restoreBackupScript = config.require("restoreBackupScript");
+
+  const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const sshPrivateKey = pulumi
+    .all([encodedSshPrivateKey])
+    .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
 
   const connection = {
     host: publicIp,

--- a/infra/setupDockerInServer.ts
+++ b/infra/setupDockerInServer.ts
@@ -9,7 +9,12 @@ export function configureServer(
   const config = new pulumi.Config();
   const mauAppTypeSenseKey = config.requireSecret("mauAppTypeSenseKey");
   const mauAppPBEncryptionKey = config.requireSecret("mauAppPBEncryptionKey");
-  const sshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const sshPrivateKey = pulumi
+    .all([encodedSshPrivateKey])
+    .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
 
   // Install Docker
   const installDocker = new command.remote.Command("installDocker", {

--- a/infra/setupEnvs.ts
+++ b/infra/setupEnvs.ts
@@ -9,7 +9,11 @@ export function configureServerEnv(
   appBucket: pulumi.Output<Bucket>,
 ) {
   const config = new pulumi.Config();
-  const sshPrivateKey = config.requireSecret("sshPrivateKey");
+  const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
+
+  const sshPrivateKey = pulumi
+    .all([encodedSshPrivateKey])
+    .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
 
   // Create necessary environment variables in the server
   const createEnvVars = new command.remote.Command("createEnvVars", {


### PR DESCRIPTION
Decode base64-encoded SSH keys across multiple scripts to
ensure compatibility and security. Include dependency for
Hetzner server creation on SSH key resource. Improves
deployment process and maintains secret integrity.