### PR TITLE
:hammer: Update docker deploy and cronjob scripts

### DIFF
--- a/infra/deployDockerStacks.ts
+++ b/infra/deployDockerStacks.ts
@@ -23,8 +23,8 @@ export const deployDockerStacks = (server: Server) => {
     },
     create: `
       # Deploy Docker stacks
-      docker stack deploy -c /home/codigo/${MAUAPPDOCKERCOMPOSE} mau-app
-      docker stack deploy -c /home/codigo/${TOOLINGDOCKERCOMPOSE} tooling
+      docker stack deploy -c ${MAUAPPDOCKERCOMPOSE} mau-app
+      docker stack deploy -c ${TOOLINGDOCKERCOMPOSE} tooling
     `,
   });
 

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -120,8 +120,8 @@ export const copyToolingDataFilesToServer = (server: Server) => {
       chmod +x /home/codigo/bin/*
 
       # Set up cron jobs
-      (crontab -l 2>/dev/null; echo "0 */12 * * * /home/codigo/.nvm/versions/node/\$(nvm current)/bin/node /home/codigo/bin/backupData.js") | crontab -
-      (crontab -l 2>/dev/null; echo "30 */12 * * * /home/codigo/.nvm/versions/node/\$(nvm current)/bin/node /home/codigo/bin/uploadToS3.js") | crontab -
+      (crontab -l 2>/dev/null; echo "0 */12 * * * \$(nvm run default) /home/codigo/bin/backupData.js") | crontab -
+      (crontab -l 2>/dev/null; echo "30 */12 * * * \$(nvm run default) /home/codigo/bin/uploadToS3.js") | crontab -
     `,
     },
     {


### PR DESCRIPTION
Simplify Docker stack deployment commands by removing hardcoded paths. 
Enhance cron jobs setup to dynamically use node via nvm default.