### PR TITLE
🔧 Update Docker stack deployment for registry integration

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -69,6 +69,8 @@ jobs:
           pulumi config set --secret mauAppTypeSenseKey "${{ secrets.MAU_APP_TYPESENSE_API_KEY }}"
           pulumi config set --secret mauAppPBEncryptionKey "${{ secrets.MAU_APP_PB_ENCRYPTION_KEY }}"
           pulumi config set --secret cloudflareApiToken "${{ secrets.CLOUDFLARE_TUNNEL_SECRET }}"
+          pulumi config set --secret dockerUsername "${{ secrets.CONTAINER_REGISTRY_USERNAME }}"
+          pulumi config set --secret dockerPassword "${{ secrets.CONTAINER_REGISTRY_PASSWORD }}"
 
           # Set SSH keys
           cat ~/.ssh/id_rsa.pub | openssl base64 | tr -d '\n' | pulumi config set sshPublicKey --secret

--- a/infra/deployDockerStacks.ts
+++ b/infra/deployDockerStacks.ts
@@ -6,9 +6,11 @@ export const deployDockerStacks = (server: Server) => {
   const config = new pulumi.Config();
 
   const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
+  const dockerUsername = config.requireSecret("dockerUsername");
+  const dockerPassword = config.requireSecret("dockerPassword");
 
-  const MAUAPPDOCKERCOMPOSE = "/home/codigo/docker-compose.mau-app.yaml";
-  const TOOLINGDOCKERCOMPOSE = "/home/codigo/docker-compose.tooling.yaml";
+  const MAUAPPDOCKERCOMPOSE = "docker-compose.mau-app.yaml";
+  const TOOLINGDOCKERCOMPOSE = "docker-compose.tooling.yaml";
 
   const sshPrivateKey = pulumi
     .all([encodedSshPrivateKey])
@@ -23,8 +25,9 @@ export const deployDockerStacks = (server: Server) => {
     },
     create: `
       # Deploy Docker stacks
-      docker stack deploy -c ${MAUAPPDOCKERCOMPOSE} mau-app
-      docker stack deploy -c ${TOOLINGDOCKERCOMPOSE} tooling
+      docker login -u ${dockerUsername} -p ${dockerPassword}
+      docker stack deploy --with-registry-auth -d --compose-file ${MAUAPPDOCKERCOMPOSE} mau-app
+      docker stack deploy --with-registry-auth -d --compose-file ${TOOLINGDOCKERCOMPOSE} tooling
     `,
   });
 


### PR DESCRIPTION
Add Docker credentials to Pulumi config for authentication. Change
Docker stack deploy commands to include --with-registry-auth for 
authorized access to private container registry. Simplify compose 
file paths for cleaner code.