### PR TITLE
🔒 refactor: secure sensitive configs with secrets

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -78,9 +78,13 @@ jobs:
           cat ~/.ssh/id_rsa | openssl base64 | tr -d '\n' | pulumi config set sshPrivateKey --secret
 
           # Set configs from files
-          for file in docker-compose.mau-app.yaml docker-compose.tooling.yaml ./tooling/data/dozzle/users.yaml ./tooling/data/shepherd/shepherd-config.yaml ./tooling/data/caddy/Caddyfile; do
+          for file in ./tooling/data/dozzle/users.yaml ./tooling/data/shepherd/shepherd-config.yaml ./tooling/data/caddy/Caddyfile; do
             pulumi config set --secret $(basename $file .yaml | tr '.-' '_') "$(cat $file)"
           done
+
+          # Set configs from files
+          pulumi config set docker_compose_mau_app_yaml "$(cat ./docker-compose.mau-app.yaml)"
+          pulumi config set docker_compose_tooling_yaml "$(cat ./docker-compose.tooling.yaml)"
 
           # Set configs from bin scripts
           for script in backupData uploadToS3 restoreAndCopyBackup; do

--- a/infra/deployDockerStacks.ts
+++ b/infra/deployDockerStacks.ts
@@ -26,6 +26,7 @@ export const deployDockerStacks = (server: Server) => {
     },
     create: pulumi.interpolate`
       # Deploy Docker stacks
+      cd /home/codigo
       echo ${dockerPassword} | docker login https://${dockerRegistry} -u ${dockerUsername} --password-stdin
       docker stack deploy --with-registry-auth -d --compose-file ${MAUAPPDOCKERCOMPOSE} mau-app
       docker stack deploy --with-registry-auth -d --compose-file ${TOOLINGDOCKERCOMPOSE} tooling

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -8,9 +8,9 @@ export const copyToolingDataFilesToServer = (server: Server) => {
 
   const docker_compose_tooling = config.require("docker_compose_tooling");
 
-  const dozzleUsers = config.require("users");
-  const shepherdConfig = config.require("shepherd_config");
-  const caddyFile = config.require("Caddyfile");
+  const dozzleUsers = config.requireSecret("users");
+  const shepherdConfig = config.requireSecret("shepherd_config");
+  const caddyFile = config.requireSecret("Caddyfile");
 
   const backupDataScript = config.require("backupDataScript");
   const uploadToS3Script = config.require("uploadToS3Script");


### PR DESCRIPTION
Change `config.require` to `config.requireSecret` for sensitive files
(users, shepherd_config, Caddyfile) in server tooling. Update GitHub
Actions to consistently handle secret configurations and separate
handling of docker-compose files. Add missing directory change
command before Docker stack deployment.