### PR TITLE
🔧 refactor: remove unnecessary stdout/stderr outputs

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -34,7 +34,6 @@ services:
     image: amir20/dozzle:latest
     deploy:
       mode: global
-      replicas: 1
       restart_policy:
         condition: on-failure
     ports:

--- a/infra/serverConfig.ts
+++ b/infra/serverConfig.ts
@@ -35,11 +35,9 @@ export const configureServer = (server: Server) => {
     }));
 
   // Create 'codigo' user and set up SSH
-  const createUser = new command.remote.Command(
-    "createUser",
-    {
-      connection: commonSshOptions,
-      create: pulumi.interpolate`
+  const createUser = new command.remote.Command("createUser", {
+    connection: commonSshOptions,
+    create: pulumi.interpolate`
       set -e
       echo "Starting user creation process..."
       if id "codigo" &>/dev/null; then
@@ -68,16 +66,6 @@ export const configureServer = (server: Server) => {
       echo "StrictHostKeyChecking no" | sudo tee /home/codigo/.ssh/config || { echo "Failed to set up SSH config"; exit 1; }
       echo "User creation and setup process completed successfully."
     `,
-    },
-    { additionalSecretOutputs: ["stdout", "stderr"] },
-  );
-
-  // Log output and errors
-  createUser.stdout.apply((stdout) => {
-    if (stdout) console.log("createUser stdout:", stdout);
-  });
-  createUser.stderr.apply((stderr) => {
-    if (stderr) console.error("createUser stderr:", stderr);
   });
 
   // Disable root SSH access
@@ -102,15 +90,8 @@ export const configureServer = (server: Server) => {
       sudo rm -f /root/.ssh/authorized_keys
     `,
     },
-    { dependsOn: [createUser], additionalSecretOutputs: ["stdout", "stderr"] },
+    { dependsOn: [createUser] },
   );
-
-  disableRootSSH.stdout.apply((stdout) => {
-    if (stdout) console.log("disableRootSSH stdout:", stdout);
-  });
-  disableRootSSH.stderr.apply((stderr) => {
-    if (stderr) console.error("disableRootSSH stderr:", stderr);
-  });
 
   // Install NVM and Node.js
   const installNode = new command.remote.Command(
@@ -144,16 +125,8 @@ export const configureServer = (server: Server) => {
     },
     {
       dependsOn: [disableRootSSH],
-      additionalSecretOutputs: ["stdout", "stderr"],
     },
   );
-
-  installNode.stdout.apply((stdout) => {
-    if (stdout) console.log("installNode stdout:", stdout);
-  });
-  installNode.stderr.apply((stderr) => {
-    if (stderr) console.error("installNode stderr:", stderr);
-  });
 
   return {
     installNode,

--- a/infra/setupDockerInServer.ts
+++ b/infra/setupDockerInServer.ts
@@ -58,8 +58,8 @@ export const setupDockerInServer = (server: Server) => {
           echo "Node is already a swarm manager."
         fi
 
-        # Output join token for workers (can be used later if needed)
-        echo "Worker join token: $(docker swarm join-token -q worker)"
+        # Capture join token for workers without echoing
+        docker swarm join-token -q worker
       `,
     },
     { dependsOn: installDocker },
@@ -118,5 +118,8 @@ export const setupDockerInServer = (server: Server) => {
     initDockerSwarm,
     createDockerNetworks,
     setupSecrets,
+    workerJoinToken: pulumi.secret(
+      initDockerSwarm.stdout.apply((token) => token.trim()),
+    ),
   };
 };

--- a/tooling/data/shepherd/shepherd-config.yaml
+++ b/tooling/data/shepherd/shepherd-config.yaml
@@ -4,7 +4,7 @@ docker:
 
 notifications:
   discord:
-    webhook: {{ DISCORD_WEBHOOK }}
+    webhook: "{{ DISCORD_WEBHOOK }}"
     # Optional: Customize the username that appears in Discord
     # Optional: Customize the notification content
     template: |


### PR DESCRIPTION
Simplify server configuration by removing stdout and stderr
attachments for commands. This reduces noise and aligns with
standard practices. Also, capture Docker swarm join token without
echoing for better security.