### PR TITLE
👷‍♂️ chore: streamline deploy-infra logging

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -59,8 +59,7 @@ jobs:
                 s|{{ ENCRYPTION_KEY }}|'"$ENCRYPTION_KEY"'|g
               ' "$file"
 
-              echo "Processed $file:"
-              cat "$file"
+              echo "Processed $file"
             else
               echo "File not found: $file"
             fi


### PR DESCRIPTION
Remove unnecessary `cat` command after processing files in 
deploy-infrastructure.yaml to reduce log clutter and improve 
readability.