### PR TITLE
:sparkles: Update Cloudflare rules to redirect HTTP to HTTPS

### DIFF
--- a/infra/cloudflare.ts
+++ b/infra/cloudflare.ts
@@ -207,7 +207,7 @@ export const createCloudflareTunnels = (serverIp: pulumi.Output<string>) => {
     zoneId: maumercadoZoneId,
     name: "maumercado-https-rule",
     kind: "zone",
-    phase: "http_request_firewall_rules",
+    phase: "http_request_redirect",
     rules: [
       {
         action: "always_use_https",
@@ -221,7 +221,7 @@ export const createCloudflareTunnels = (serverIp: pulumi.Output<string>) => {
     zoneId: codigoZoneId,
     name: "codigo-https-rule",
     kind: "zone",
-    phase: "http_request_firewall_rules",
+    phase: "http_request_redirect",
     rules: [
       {
         action: "always_use_https",


### PR DESCRIPTION
Change the phase from `http_request_firewall_rules`
to `http_request_redirect` to ensure proper HTTP to
HTTPS redirection for both `codigo` and `maumercado`
zones.