### PR TITLE
✨ refactor: improve docker secrets and cloudflare setup

### DIFF
--- a/docker-compose.mau-app.yaml
+++ b/docker-compose.mau-app.yaml
@@ -53,17 +53,15 @@ services:
     volumes:
       - /home/codigo/mau-app/data/typesense:/data
     command:
-      - --data-dir
-      - /data
-      - --api-key
-      - ${TYPESENSE_API_KEY}
+      - --data-dir=/data
+      - --api-key=${TYPESENSE_API_KEY}
     environment:
-      TYPESENSE_API_KEY: /run/secrets/typesense_api_key
+      TYPESENSE_API_KEY: /run/secrets/mau-app_typesense_api_key
     networks:
       - internal_net
       - caddy_net
     secrets:
-      - typesense_api_key
+      - mau-app_typesense_api_key
 
 secrets:
   encryption_key:

--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -57,27 +57,31 @@ services:
 
   cloudflared-maumercado:
     image: cloudflare/cloudflared:latest
-    command: tunnel --no-autoupdate run --token $(cat /run/secrets/maumercado_tunnel_token)
-    secrets:
-      - maumercado_tunnel_token
+    command: tunnel run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    environment:
+      - CLOUDFLARE_TUNNEL_TOKEN=/run/secrets/maumercado_tunnel_token
     networks:
       - caddy_net
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
+    secrets:
+      - maumercado_tunnel_token
 
   cloudflared-codigo:
     image: cloudflare/cloudflared:latest
-    command: tunnel --no-autoupdate run --token $(cat /run/secrets/codigo_tunnel_token)
-    secrets:
-      - codigo_tunnel_token
+    command: tunnel run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    environment:
+      - CLOUDFLARE_TUNNEL_TOKEN=/run/secrets/codigo_tunnel_token
     networks:
       - caddy_net
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
+    secrets:
+      - codigo_tunnel_token
 
 networks:
   caddy_net:

--- a/infra/cloudflare.ts
+++ b/infra/cloudflare.ts
@@ -112,7 +112,7 @@ export const createCloudflareTunnels = () => {
           name: record.name,
           zoneId: record.zoneId,
           type: "CNAME",
-          value: record.tunnel.id.apply((id) => `${id}.cfargotunnel.com`),
+          content: record.tunnel.id.apply((id) => `${id}.cfargotunnel.com`),
           proxied: true,
         },
         {

--- a/infra/setupDockerInServer.ts
+++ b/infra/setupDockerInServer.ts
@@ -101,10 +101,10 @@ export const setupDockerInServer = (
           docker secret ls --format '{{.Name}}' | grep -q "^codigo_tunnel_token$" && docker secret rm codigo_tunnel_token
 
           # Create new secrets
-          echo "${maumercadoTunnelToken}" | docker secret create maumercado_tunnel_token -
-          echo "${codigoTunnelToken}" | docker secret create codigo_tunnel_token -
           echo "${mauAppTypeSenseKey}" | docker secret create mau-app_typesense_api_key -
           echo "${mauAppPBEncryptionKey}" | docker secret create mau-app_pb_encryption_key -
+          echo "${maumercadoTunnelToken}" | docker secret create maumercado_tunnel_token -
+          echo "${codigoTunnelToken}" | docker secret create codigo_tunnel_token -
           echo "Docker secrets created successfully."
         else
           echo "Error: Docker Swarm is not active. Cannot create secrets."


### PR DESCRIPTION
Refactor Docker secrets creation order for consistency in 
infra/setupDockerInServer.ts. Simplify and unify commands in 
docker-compose.mau-app.yaml and docker-compose.tooling.yaml. 

Update docker-compose.mau-app.yaml to use a consistent naming convention 
for the mau-app_typesense_api_key secret. Fix CNAME record value field to 
content in infra/cloudflare.ts for correct configuration.