### PR TITLE
🔒️ infra: use `requireSecret` for sensitive data

### DIFF
--- a/infra/cloudflare.ts
+++ b/infra/cloudflare.ts
@@ -3,9 +3,9 @@ import * as cloudflare from "@pulumi/cloudflare";
 import * as random from "@pulumi/random";
 
 const config = new pulumi.Config();
-const accountId = config.require("cloudflareAccountId");
-const maumercadoZoneId = config.require("cloudflareMaumercadoZoneId");
-const codigoZoneId = config.require("cloudflareCodigoZoneId");
+const accountId = config.requireSecret("cloudflareAccountId");
+const maumercadoZoneId = config.requireSecret("cloudflareMaumercadoZoneId");
+const codigoZoneId = config.requireSecret("cloudflareCodigoZoneId");
 
 interface DnsRecordArgs {
   name: string;


### PR DESCRIPTION
Change `config.require` to `requireSecret` for Cloudflare credentials
to enhance security by ensuring sensitive information is encrypted
and protected.