### PR TITLE
🎨 Update serverCopyToolingFiles to use multi-line strings

### DIFF
--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -52,7 +52,10 @@ export const copyToolingDataFilesToServer = (server: Server) => {
     "copy docker compose tooling",
     {
       connection,
-      create: pulumi.interpolate`echo '${docker_compose_tooling}' > /home/codigo/docker-compose.tooling.yaml`,
+      create: pulumi.interpolate`cat << 'EOF' > /home/codigo/docker-compose.tooling.yaml
+        ${docker_compose_tooling}
+        EOF
+      `,
     },
     { dependsOn: createToolingFolders },
   );


### PR DESCRIPTION
Enhance the `copyToolingDataFilesToServer` function to use a
multi-line string (here-document) for creating the `docker-compose.tooling.yaml`
file, instead of a single echo command, for improved readability
and maintainability.