### PR TITLE
✨ Improve Docker setup and logging

### DIFF
--- a/docker-compose.mau-app.yaml
+++ b/docker-compose.mau-app.yaml
@@ -52,11 +52,8 @@ services:
         condition: on-failure
     volumes:
       - /home/codigo/mau-app/data/typesense:/data
-    command:
-      - --data-dir=/data
-      - --api-key=${TYPESENSE_API_KEY}
-    environment:
-      TYPESENSE_API_KEY: /run/secrets/mau-app_typesense_api_key
+    command: >
+      sh -c "typesense-server --data-dir=/data --api-key=$$(cat /run/secrets/mau-app_typesense_api_key)"
     networks:
       - internal_net
       - caddy_net

--- a/infra/serverCopyMauAppFiles.ts
+++ b/infra/serverCopyMauAppFiles.ts
@@ -39,7 +39,10 @@ export const copyMauAppDataFilesToServer = (server: Server) => {
     "scp docker compose mau app ",
     {
       connection: commonSshOptions,
-      create: pulumi.interpolate`echo '${docker_compose_mau_app}' > /home/codigo/docker-compose.mau-app.yaml`,
+      create: pulumi.interpolate`cat << EOF > /home/codigo/docker-compose.mau-app.yaml
+${docker_compose_mau_app}
+EOF
+`,
     },
     { dependsOn: createMauAppFolders },
   );

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -52,10 +52,10 @@ export const copyToolingDataFilesToServer = (server: Server) => {
     "copy docker compose tooling",
     {
       connection,
-      create: pulumi.interpolate`cat << 'EOF' > /home/codigo/docker-compose.tooling.yaml
-        ${docker_compose_tooling}
-        EOF
-      `,
+      create: pulumi.interpolate`cat << EOF > /home/codigo/docker-compose.tooling.yaml
+${docker_compose_tooling}
+EOF
+`,
     },
     { dependsOn: createToolingFolders },
   );


### PR DESCRIPTION
- Update `copyToolingDataFilesToServer` to use cleaner here-doc
  syntax for `docker-compose.tooling.yaml` creation.
- Refactor `setupSecrets` in `setupDockerInServer` for better
  readability and maintainability.
- Enhance command in `docker-compose.mau-app.yaml` to read the
  API key directly from file.
- Remove redundant `pulumi.log` statements for tunnel tokens.