### PR TITLE
♻️ refactor: use literal EOF markers for tooling/mau files

### DIFF
--- a/infra/serverCopyMauAppFiles.ts
+++ b/infra/serverCopyMauAppFiles.ts
@@ -39,7 +39,7 @@ export const copyMauAppDataFilesToServer = (server: Server) => {
     "scp docker compose mau app ",
     {
       connection: commonSshOptions,
-      create: pulumi.interpolate`cat << EOF > /home/codigo/docker-compose.mau-app.yaml
+      create: pulumi.interpolate`cat << 'EOF' > /home/codigo/docker-compose.mau-app.yaml
 ${docker_compose_mau_app}
 EOF
 `,

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -52,7 +52,7 @@ export const copyToolingDataFilesToServer = (server: Server) => {
     "copy docker compose tooling",
     {
       connection,
-      create: pulumi.interpolate`cat << EOF > /home/codigo/docker-compose.tooling.yaml
+      create: pulumi.interpolate`cat << 'EOF' > /home/codigo/docker-compose.tooling.yaml
 ${docker_compose_tooling}
 EOF
 `,


### PR DESCRIPTION
Replace plain EOF markers with literal ones in server copy scripts.
This ensures that variable substitutions are correctly handled, which
prevents potential errors during file creation on the server.