### PR TITLE
feat: 🐳 improve docker-compose configurations

### DIFF
--- a/docker-compose.mau-app.yaml
+++ b/docker-compose.mau-app.yaml
@@ -52,8 +52,9 @@ services:
         condition: on-failure
     volumes:
       - /home/codigo/mau-app/data/typesense:/data
-    command: >
-      sh -c "typesense-server --data-dir=/data --api-key=$$(cat /run/secrets/mau-app_typesense_api_key)"
+    command:
+      - --data-dir=/data
+      - --api-key=$$(cat /run/secrets/mau-app_typesense_api_key)
     networks:
       - internal_net
       - caddy_net

--- a/infra/serverCopyMauAppFiles.ts
+++ b/infra/serverCopyMauAppFiles.ts
@@ -39,7 +39,7 @@ export const copyMauAppDataFilesToServer = (server: Server) => {
     "scp docker compose mau app ",
     {
       connection: commonSshOptions,
-      create: pulumi.interpolate`cat << 'EOF' > /home/codigo/docker-compose.mau-app.yaml
+      create: pulumi.interpolate`cat << EOF > /home/codigo/docker-compose.mau-app.yaml
 ${docker_compose_mau_app}
 EOF
 `,

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -52,7 +52,7 @@ export const copyToolingDataFilesToServer = (server: Server) => {
     "copy docker compose tooling",
     {
       connection,
-      create: pulumi.interpolate`cat << 'EOF' > /home/codigo/docker-compose.tooling.yaml
+      create: pulumi.interpolate`cat << EOF > /home/codigo/docker-compose.tooling.yaml
 ${docker_compose_tooling}
 EOF
 `,


### PR DESCRIPTION
Refactor docker-compose command syntax for better readability
and consistency. Remove single quotes in EOF markers in 
serverCopyToolingFiles.ts and serverCopyMauAppFiles.ts to 
enable correct variable interpolation. These changes improve 
maintenance and clarity in the deployment scripts.