### PR TITLE
:hammer: Simplify tunnel commands in docker-compose

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -57,11 +57,10 @@ services:
 
   cloudflared-maumercado:
     image: cloudflare/cloudflared:latest
-    command: >
-      sh -c '
-      echo "Command to be executed: tunnel run --token $$(cat /run/secrets/maumercado_tunnel_token | cut -c1-5)..." &&
-      tunnel run --token $$(cat /run/secrets/maumercado_tunnel_token)
-      '
+    command:
+      - tunnel
+      - run
+      - --token=$$(cat /run/secrets/maumercado_tunnel_token)
     networks:
       - caddy_net
     deploy:
@@ -73,11 +72,10 @@ services:
 
   cloudflared-codigo:
     image: cloudflare/cloudflared:latest
-    command: >
-      sh -c '
-      echo "Command to be executed: tunnel run --token $$(cat /run/secrets/codigo_tunnel_token | cut -c1-5)..." &&
-      tunnel run --token $$(cat /run/secrets/codigo_tunnel_token)
-      '
+    command:
+      - tunnel
+      - run
+      - --token=$$(cat /run/secrets/codigo_tunnel_token)
     networks:
       - caddy_net
     deploy:


### PR DESCRIPTION
Refactor cloudflared services to use simpler command format,
eliminating unnecessary `sh -c` usage. Enhances readability and
maintains functionality.