### PR TITLE
💡 feat: Refactor entrypoints and commands in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@
 **/pocketbase/*
 !**/pocketbase/.gitkeep
 
+!**/bin/pocketbase/*.sh
+!**/bin/typesense/*.sh
+
 .DS_Store

--- a/docker-compose.mau-app.yaml
+++ b/docker-compose.mau-app.yaml
@@ -29,9 +29,7 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-    command:
-      - --encryptionEnv
-      - $$(cat /run/secrets/mau-app_pb_encryption_key)
+    entrypoint: ["/bin/sh", "/run/entrypoint.sh"]
     volumes:
       - /home/codigo/mau-app/data/pocketbase/pb_data:/pb_data
       - /home/codigo/mau-app/data/pocketbase/pb_public:/pb_public
@@ -41,31 +39,41 @@ services:
       - caddy_net
     secrets:
       - mau-app_pb_encryption_key
+    configs:
+      - source: mau-app_pocketbase_entrypoint
+        target: /run/entrypoint.sh
+        mode: 0755
 
   typesense:
-    image: typesense/typesense:26.0
+    image: typesense/typesense:27.0
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
+    entrypoint: ["/bin/sh", "/run/entrypoint.sh"]
     volumes:
       - /home/codigo/mau-app/data/typesense:/data
-    command:
-      - --data-dir
-      - /data
-      - --api-key
-      - $$(cat /run/secrets/mau-app_typesense_api_key)
     networks:
       - internal_net
       - caddy_net
     secrets:
       - mau-app_typesense_api_key
+    configs:
+      - source: mau-app_typesense_entrypoint
+        target: /run/entrypoint.sh
+        mode: 0755
 
 secrets:
   mau-app_pb_encryption_key:
     external: true
   mau-app_typesense_api_key:
     external: true
+
+configs:
+  mau-app_typesense_entrypoint:
+    file: /home/codigo/mau-app/bin/typesense/entrypoint.sh
+  mau-app_pocketbase_entrypoint:
+    file: /home/codigo/mau-app/bin/pocketbase/entrypoint.sh
 
 networks:
   internal_net:

--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -57,11 +57,7 @@ services:
 
   cloudflared-maumercado:
     image: cloudflare/cloudflared:latest
-    command:
-      - tunnel
-      - run
-      - --token
-      - $$(cat /run/secrets/maumercado_tunnel_token)
+    entrypoint: ["/bin/sh", "/run/entrypoint.sh"]
     networks:
       - caddy_net
     deploy:
@@ -70,14 +66,14 @@ services:
         condition: on-failure
     secrets:
       - maumercado_tunnel_token
+    configs:
+      - source: cloudflared_maumercado_entrypoint
+        target: /run/entrypoint.sh
+        mode: 0755
 
   cloudflared-codigo:
     image: cloudflare/cloudflared:latest
-    command:
-      - tunnel
-      - run
-      - --token
-      - $$(cat /run/secrets/codigo_tunnel_token)
+    entrypoint: ["/bin/sh", "/run/entrypoint.sh"]
     networks:
       - caddy_net
     deploy:
@@ -86,6 +82,10 @@ services:
         condition: on-failure
     secrets:
       - codigo_tunnel_token
+    configs:
+      - source: cloudflared_codigo_entrypoint
+        target: /run/entrypoint.sh
+        mode: 0755
 
 networks:
   caddy_net:
@@ -96,6 +96,10 @@ configs:
     file: /home/codigo/tooling/data/caddy/Caddyfile
   shepherd_config:
     file: /home/codigo/tooling/data/shepherd/shepherd-config.yaml
+  cloudflared_maumercado_entrypoint:
+    file: /home/codigo/tooling/bin/cloudflared/maumercado_entrypoint.sh
+  cloudflared_codigo_entrypoint:
+    file: /home/codigo/tooling/bin/cloudflared/codigo_entrypoint.sh
 
 secrets:
   users:

--- a/mau-app/bin/pocketbase/entrypoint.sh
+++ b/mau-app/bin/pocketbase/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ENCRYPTION_KEY=$(cat /run/secrets/mau-app_pb_encryption_key)
+exec pocketbase serve --dir /pb_data --publicDir /pb_public --migrationsDir /pb_migrations --encryptionEnv ${ENCRYPTION_KEY} --http=0.0.0.0:8090 --hooksDir=/pb_hooks

--- a/mau-app/bin/typesense/entrypoint.sh
+++ b/mau-app/bin/typesense/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+TOKEN=$(cat /run/secrets/mau-app_typesense_api_key)
+exec typesense --data-dir /data --api-key "$TOKEN"

--- a/tooling/bin/cloudflared/codigo_entrypoint.sh
+++ b/tooling/bin/cloudflared/codigo_entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+TOKEN=$(cat /run/secrets/codigo_tunnel_token)
+exec cloudflared tunnel run --token "$TOKEN"

--- a/tooling/bin/cloudflared/maumercado_entrypoint.sh
+++ b/tooling/bin/cloudflared/maumercado_entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+TOKEN=$(cat /run/secrets/maumercado_tunnel_token)
+exec cloudflared tunnel run --token "$TOKEN"


### PR DESCRIPTION
Refactor entrypoint scripts for Cloudflared, Pocketbase, and
Typesense to use shell scripts for loading secrets. Update
docker-compose files to use these entrypoints for better
maintainability and readability. Upgrade Typesense image
from version 26.0 to 27.0. Add corresponding configurations
in the `.gitignore` file.