### PR TITLE
🚀 infra: add entrypoint setup and new directories

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -114,6 +114,12 @@ jobs:
             pulumi config set --secret ${script}Script "$(cat ./bin/${script}.js)"
           done
 
+          # Set entrypoints from bin scripts
+          pulumi config set pocketbaseEntrypoint "$(cat ./mau-app/bin/pocketbase/entrypoint.sh)"
+          pulumi config set typesenseEntrypoint "$(cat ./mau-app/bin/typesense/entrypoint.sh)"
+          pulumi config set cloudflaredMaumercadoEntrypoint "$(cat ./tooling/bin/cloudflared/maumercado_entrypoint.sh)"
+          pulumi config set cloudflaredCodigoEntrypoint "$(cat ./tooling/bin/cloudflared/codigo_entrypoint.sh)"
+
           # Set backup directory
           pulumi config set backupDir ${{ vars.BACKUP_DIR }}
 

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -20,6 +20,9 @@ export const copyToolingDataFilesToServer = (server: Server) => {
 
   const encodedSshPrivateKey = config.requireSecret("sshPrivateKey");
 
+  const cloudflaredMaumercadoEntrypoint = config.require("cloudflaredMaumercadoEntrypoint");
+  const cloudflaredCodigoEntrypoint = config.require("cloudflaredCodigoEntrypoint");
+
   const sshPrivateKey = pulumi
     .all([encodedSshPrivateKey])
     .apply(([encoded]) => Buffer.from(encoded, "base64").toString("utf-8"));
@@ -41,9 +44,28 @@ export const copyToolingDataFilesToServer = (server: Server) => {
       mkdir -p /home/codigo/tooling/data/caddy/data &&
       mkdir -p /home/codigo/tooling/data/dozzle &&
       mkdir -p /home/codigo/tooling/data/shepherd &&
-      mkdir -p /home/codigo/tooling/data/typesense
+      mkdir -p /home/codigo/tooling/data/typesense &&
+      mkdir -p /home/codigo/tooling/bin/cloudflared
     `,
     },
+  );
+
+  const scpCloudflaredMaumercadoEntrypoint = new command.remote.Command(
+    "copy cloudflared maumercado entrypoint",
+    {
+      connection,
+      create: pulumi.interpolate`echo '${cloudflaredMaumercadoEntrypoint}' > /home/codigo/tooling/bin/cloudflared/maumercado_entrypoint.sh && chmod +x /home/codigo/tooling/bin/cloudflared/maumercado_entrypoint.sh`,
+    },
+    { dependsOn: createToolingFolders },
+  );
+
+  const scpCloudflaredCodigoEntrypoint = new command.remote.Command(
+    "copy cloudflared codigo entrypoint",
+    {
+      connection,
+      create: pulumi.interpolate`echo '${cloudflaredCodigoEntrypoint}' > /home/codigo/tooling/bin/cloudflared/codigo_entrypoint.sh && chmod +x /home/codigo/tooling/bin/cloudflared/codigo_entrypoint.sh`,
+    },
+    { dependsOn: createToolingFolders },
   );
 
   // SCP commands to copy docker compose tooling string to the server
@@ -143,5 +165,7 @@ EOF
     scpToolingDataShepherd,
     scpCaddyFile,
     setPermissionsAndCronJob,
+    scpCloudflaredMaumercadoEntrypoint,
+    scpCloudflaredCodigoEntrypoint,
   };
 };


### PR DESCRIPTION
Add creation of new directories for Pocketbase and Typesense
in 'copyMauAppDataFilesToServer' and 'copyToolingDataFilesToServer'.
Include commands to SCP entrypoint scripts to the server for both
applications. Update GitHub Actions workflow to configure these
entrypoints in Pulumi config for proper deployment.