### PR TITLE
✨ refactor: improve token injection for docker-compose

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -61,7 +61,7 @@ services:
       - tunnel
       - run
       - --token
-      - '{{ MAUMERCADO_TUNNEL_TOKEN }}'
+      - "{{ MAUMERCADO_TUNNEL_TOKEN }}"
     networks:
       - caddy_net
     deploy:
@@ -75,7 +75,7 @@ services:
       - tunnel
       - run
       - --token
-      - '{{ CODIGO_TUNNEL_TOKEN }}'
+      - "{{ CODIGO_TUNNEL_TOKEN }}"
 
     networks:
       - caddy_net

--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -11,15 +11,14 @@ export const copyToolingDataFilesToServer = (
   const config = new pulumi.Config();
 
   const docker_compose_tooling = config.require("docker_compose_tooling");
-  const maumercadoTunnelTokenValue = maumercadoTunnelToken.get();
-  const codigoTunnelTokenValue = codigoTunnelToken.get();
 
   // Inject the tunnel tokens into the docker_compose_tooling
-  const injectedDockerComposeTooling =
-    pulumi.interpolate`${docker_compose_tooling}`.apply((compose) =>
+  const injectedDockerComposeTooling = pulumi
+    .all([docker_compose_tooling, maumercadoTunnelToken, codigoTunnelToken])
+    .apply(([compose, maumercadoToken, codigoToken]) =>
       compose
-        .replace("'{{ MAUMERCADO_TUNNEL_TOKEN }}'", maumercadoTunnelTokenValue)
-        .replace("'{{ CODIGO_TUNNEL_TOKEN }}'", codigoTunnelTokenValue),
+        .replace('"{{ MAUMERCADO_TUNNEL_TOKEN }}"', maumercadoToken)
+        .replace('"{{ CODIGO_TUNNEL_TOKEN }}"', codigoToken),
     );
 
   const dozzleUsers = config.requireSecret("users");


### PR DESCRIPTION
Standardize token quotes in docker-compose.tooling.yaml to double
quotes for consistency. Refactor token injection in
serverCopyToolingFiles.ts to use .all and streamline the process of
dynamic token replacement for efficiency and maintainability.