### PR TITLE
:sparkles: Update environment var LOG_LEVEL to PUBLIC_LOG_LEVEL

### DIFF
--- a/docker-compose.mau-app.yaml
+++ b/docker-compose.mau-app.yaml
@@ -7,7 +7,7 @@ services:
         condition: on-failure
     environment:
       DEBUG: "true"
-      LOG_LEVEL: "debug"
+      PUBLIC_LOG_LEVEL: "debug"
     ports:
       - "3000"
     networks:
@@ -22,7 +22,7 @@ services:
         condition: on-failure
     environment:
       DEBUG: "true"
-      LOG_LEVEL: "debug"
+      PUBLIC_LOG_LEVEL: "debug"
     ports:
       - "3000"
     networks:


### PR DESCRIPTION
Change LOG_LEVEL to PUBLIC_LOG_LEVEL for better readability
and accuracy in both service definitions in docker-compose.