### PR TITLE
:rocket: Add support for versioned Docker tags

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -38,6 +38,7 @@ jobs:
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           TYPESENSE_API_KEY: ${{ secrets.MAU_APP_TYPESENSE_API_KEY }}
           ENCRYPTION_KEY: ${{ secrets.MAU_APP_PB_ENCRYPTION_KEY }}
+          TAG: ${{ github.event.client_payload.tag }}
         run: |
           files=(
             "./tooling/data/dozzle/users.yaml"
@@ -61,6 +62,7 @@ jobs:
                 s|{{ DOCKER_REGISTRY_PASSWORD }}|'"$DOCKER_REGISTRY_PASSWORD"'|g
                 s|{{ TYPESENSE_API_KEY }}|'"$TYPESENSE_API_KEY"'|g
                 s|{{ ENCRYPTION_KEY }}|'"$ENCRYPTION_KEY"'|g
+                s|{{ TAG }}|'"$TAG"'|g
               ' "$file"
 
               echo "Processed $file"

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,29 @@
+services:
+  pocketbase:
+    image: ghcr.io/muchobien/pocketbase:latest
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - ./mau-app/data/pocketbase/pb_data:/pb_data
+      - ./mau-app/data/pocketbase/pb_public:/pb_public
+      - ./mau-app/data/pocketbase/pb_migrations:/pb_migrations
+    ports:
+      - "8090:8090"
+    environment:
+      PB_ENCRYPTION_KEY: ${PB_ENCRYPTION_KEY}
+
+  typesense:
+    image: typesense/typesense:27.0
+    command: ["--data-dir", "/data", "--api-key", "${TYPESENSE_API_KEY}"]
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - ./mau-app/data/typesense:/data
+    ports:
+      - "8108:8108"
+    environment:
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY}

--- a/tooling/data/shepherd/shepherd-config.yaml
+++ b/tooling/data/shepherd/shepherd-config.yaml
@@ -23,11 +23,11 @@ auth:
       password: "{{ DOCKER_REGISTRY_PASSWORD }}"
 services:
   - name: mau-app-codigo
-    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:latest"
+    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:{{ TAG }}"
     auth:
       registry: "{{ CONTAINER_REGISTRY_URL }}"
   - name: mau-app-maumercado
-    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:latest"
+    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:{{ TAG }}"
     auth:
       registry: "{{ CONTAINER_REGISTRY_URL }}"
   - name: mau-app_pocketbase


### PR DESCRIPTION
Include TAG in deploy-infrastructure.yaml to accommodate versioned
Docker images. Update shepherd-config.yaml to use tagged versions of
mau-app services for more robust and traceable deployments. Add
docker-compose.dev.yaml to facilitate local development with
Pocketbase and Typesense services.