### PR TITLE
🎨 Refactor: Remove usage of TAG env variable

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -38,7 +38,6 @@ jobs:
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           TYPESENSE_API_KEY: ${{ secrets.MAU_APP_TYPESENSE_API_KEY }}
           ENCRYPTION_KEY: ${{ secrets.MAU_APP_PB_ENCRYPTION_KEY }}
-          TAG: ${{ github.event.client_payload.tag }}
         run: |
           files=(
             "./tooling/data/dozzle/users.yaml"
@@ -62,7 +61,6 @@ jobs:
                 s|{{ DOCKER_REGISTRY_PASSWORD }}|'"$DOCKER_REGISTRY_PASSWORD"'|g
                 s|{{ TYPESENSE_API_KEY }}|'"$TYPESENSE_API_KEY"'|g
                 s|{{ ENCRYPTION_KEY }}|'"$ENCRYPTION_KEY"'|g
-                s|{{ TAG }}|'"$TAG"'|g
               ' "$file"
 
               echo "Processed $file"

--- a/tooling/data/shepherd/shepherd-config.yaml
+++ b/tooling/data/shepherd/shepherd-config.yaml
@@ -15,7 +15,7 @@ notifications:
 
 auth:
   registries:
-    - server: "{{ CONTAINER_REGISTRY_URL }}"
+    - server: https://"{{ CONTAINER_REGISTRY_URL }}"
       username: "{{ CONTAINER_REGISTRY_USERNAME }}"
       password: "{{ CONTAINER_REGISTRY_PASSWORD }}"
     - server: "https://registry-1.docker.io"
@@ -23,13 +23,13 @@ auth:
       password: "{{ DOCKER_REGISTRY_PASSWORD }}"
 services:
   - name: mau-app-codigo
-    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:{{ TAG }}"
+    image: https://"{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:latest"
     auth:
-      registry: "{{ CONTAINER_REGISTRY_URL }}"
+      registry: https://"{{ CONTAINER_REGISTRY_URL }}"
   - name: mau-app-maumercado
-    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:{{ TAG }}"
+    image: https://"{{ CONTAINER_REGISTRY_URL }}/codigo/mau-app:latest"
     auth:
-      registry: "{{ CONTAINER_REGISTRY_URL }}"
+      registry: https://"{{ CONTAINER_REGISTRY_URL }}"
   - name: mau-app_pocketbase
     image: ghcr.io/muchobien/pocketbase:latest
     auth:


### PR DESCRIPTION
Eliminate the use of the `TAG` environment variable in 
deploy-infrastructure workflow and shepherd-config.yaml files 
to simplify the deployment process. Replace it with hardcoded 
"latest" tags for container images and use full URLs for 
container registry paths to ensure consistency.