### PR TITLE
✨ infra: improve cron jobs with logging and permissions

### DIFF
--- a/infra/serverCopyToolingFiles.ts
+++ b/infra/serverCopyToolingFiles.ts
@@ -136,9 +136,16 @@ EOF
       # Set correct permissions
       chmod +x /home/codigo/bin/*
 
-      # Set up cron jobs
-      (crontab -l 2>/dev/null; echo "0 */12 * * * \$(nvm run default) /home/codigo/bin/backupData.js") | crontab -
-      (crontab -l 2>/dev/null; echo "30 */12 * * * \$(nvm run default) /home/codigo/bin/uploadToS3.js") | crontab -
+      # Set up cron jobs with logging
+      (crontab -l 2>/dev/null; echo "0 */12 * * * sudo -u codigo \$(nvm which default) /home/codigo/bin/backupData.js >> /home/codigo/logs/backupData.log 2>&1") | crontab -
+      (crontab -l 2>/dev/null; echo "30 */12 * * * sudo -u codigo \$(nvm which default) /home/codigo/bin/uploadToS3.js >> /home/codigo/logs/uploadToS3.log 2>&1") | crontab -
+
+      # Create log directory if it doesn't exist
+      mkdir -p /home/codigo/logs
+
+      # Set appropriate permissions for the log directory
+      chown codigo:codigo /home/codigo/logs
+      chmod 755 /home/codigo/logs
     `,
     },
     {


### PR DESCRIPTION
Introduce logging for cron jobs by redirecting output to log files.
Ensure log directory creation and proper permissions setup to avoid
permission issues. Run cron jobs as 'codigo' user for security.