### PR TITLE
🛠️ Add Cloudflared service, fallback in Caddyfile

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -39,6 +39,20 @@ services:
     networks:
       - caddy_net
 
+  cloudflared-maumercado:
+    image: cloudflare/cloudflared:latest
+    command:
+      - tunnel
+      - run
+      - --token
+      - "{{ MAUMERCADO_TUNNEL_TOKEN }}"
+    networks:
+      - caddy_net
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+
   cloudflared-codigo:
     image: cloudflare/cloudflared:latest
     command:

--- a/tooling/data/caddy/Caddyfile
+++ b/tooling/data/caddy/Caddyfile
@@ -44,4 +44,9 @@
 			header_up CF-Ray {http.request.header.CF-Ray}
 		}
 	}
+
+	# Catch-all for other requests
+	handle {
+		respond "Not Found" 404
+	}
 }


### PR DESCRIPTION
Introduce the cloudflared-maumercado service in
docker-compose.tooling.yaml with auto-restart on failure to enhance
tunneling. Add a fallback handle in the Caddyfile for unmatched
requests, improving error handling and client response.