### PR TITLE
🛠️ Add container-updater and enhance docs

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -38,6 +38,7 @@ jobs:
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           TYPESENSE_API_KEY: ${{ secrets.MAU_APP_TYPESENSE_API_KEY }}
           ENCRYPTION_KEY: ${{ secrets.MAU_APP_PB_ENCRYPTION_KEY }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: |
           files=(
             "./tooling/data/dozzle/users.yaml"
@@ -60,6 +61,7 @@ jobs:
                 s|{{ DOCKER_REGISTRY_PASSWORD }}|'"$DOCKER_REGISTRY_PASSWORD"'|g
                 s|{{ TYPESENSE_API_KEY }}|'"$TYPESENSE_API_KEY"'|g
                 s|{{ ENCRYPTION_KEY }}|'"$ENCRYPTION_KEY"'|g
+                s|{{ JWT_SECRET }}|'"$JWT_SECRET"'|g
               ' "$file"
 
               echo "Processed $file"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains the infrastructure-as-code and deployment configuration
 - Automated backups to S3
 - Reverse proxy and SSL termination (Caddy)
 - Monitoring and logging (Dozzle)
-- Automatic Docker image updates (TODO as shepherd is not used anymore)
+- Custom API for updating Docker images [(container-updater)](https://github.com/codigo/container-updater)
 
 ## Infrastructure Deployment Flow
 
@@ -94,6 +94,25 @@ The deployment is fully automated and includes:
 - **Caddy**: Reverse proxy and SSL termination
 - **Dozzle**: Docker container log viewer
 - **Cloudflared**: Cloudflare tunnel client for secure access
+- **container-updater**: Custom service for updating Docker containers
+
+### container-updater
+
+The container-updater is a custom service designed to facilitate automatic updates of Docker containers in the swarm. It exposes an endpoint `/update` that accepts POST requests with the following characteristics:
+
+- **Payload**: Includes the `appName` of the container to be updated
+- **Authentication**: Protected by a JWT Secret
+- **Functionality**: Uses Docker Swarm commands to update the specified container with a new image
+- **Trigger**: Designed to be called by a GitHub Action when a new image is available
+
+To update a container:
+
+1. A GitHub Action builds and pushes a new image
+2. The Action then sends a POST request to `https://updater.codigo.sh/update` with the `appName` in the payload
+3. The request must include a valid JWT for authentication
+4. The container-updater service receives the request and triggers the update in the Docker Swarm
+
+This approach allows for secure, automated updates of specific containers without manual intervention.
 
 ## Customization
 
@@ -102,7 +121,8 @@ The deployment is fully automated and includes:
 
 ## Maintenance
 
-- TODO as shepherd is not used anymore
+- Regular updates are handled automatically by the container-updater service
+- Monitor logs via Dozzle for any issues during updates
 
 ## Security
 
@@ -110,6 +130,7 @@ The deployment is fully automated and includes:
 - Only the `codigo` user can SSH into the server
 - Sensitive data stored in GitHub secrets and Pulumi config
 - Cloudflare Tunnels provide secure access without exposing ports
+- container-updater endpoint is protected by JWT authentication
 
 ## Development
 

--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -21,6 +21,19 @@ services:
       retries: 3
       start_period: 30s
 
+  codigo-updater:
+    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/codigo-updater:latest"
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    environment:
+      - JWT_SECRET=${JWT_SECRET}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - caddy_net
+
   dozzle:
     image: amir20/dozzle:latest
     deploy:

--- a/tooling/data/caddy/Caddyfile
+++ b/tooling/data/caddy/Caddyfile
@@ -11,7 +11,9 @@
 			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
 			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
 			header_up X-Forwarded-Host {http.request.host}
+			header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
 			header_up CF-Ray {http.request.header.CF-Ray}
+			header_up CF-Connecting-IP {http.request.header.CF-Connecting-IP}
 		}
 	}
 
@@ -21,27 +23,45 @@
 			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
 			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
 			header_up X-Forwarded-Host {http.request.host}
+			header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
 			header_up CF-Ray {http.request.header.CF-Ray}
+			header_up CF-Connecting-IP {http.request.header.CF-Connecting-IP}
 		}
 	}
 
 	@typesense host typesense.codigo.sh typesense.maumercado.com
 	handle @typesense {
 		reverse_proxy typesense:8108 {
+			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
 			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
-			header_up X-Forwarded-Host {http.request.header.X-Forwarded-Host}
+			header_up X-Forwarded-Host {http.request.host}
 			header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
 			header_up CF-Ray {http.request.header.CF-Ray}
+			header_up CF-Connecting-IP {http.request.header.CF-Connecting-IP}
 		}
 	}
 
 	@dozzle host dozzle.codigo.sh dozzle.maumercado.com
 	handle @dozzle {
 		reverse_proxy dozzle:8080 {
+			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
 			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
-			header_up X-Forwarded-Host {http.request.header.X-Forwarded-Host}
+			header_up X-Forwarded-Host {http.request.host}
 			header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
 			header_up CF-Ray {http.request.header.CF-Ray}
+			header_up CF-Connecting-IP {http.request.header.CF-Connecting-IP}
+		}
+	}
+
+	@codigo_updater host updater.codigo.sh updater.maumercado.com
+	handle @codigo_updater {
+		reverse_proxy codigo-updater:3000 {
+			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
+			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
+			header_up X-Forwarded-Host {http.request.host}
+			header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
+			header_up CF-Ray {http.request.header.CF-Ray}
+			header_up CF-Connecting-IP {http.request.header.CF-Connecting-IP}
 		}
 	}
 


### PR DESCRIPTION
Integrate container-updater service to auto-update Docker
containers via GitHub Actions. Document the new service
with usage instructions and JWT authentication setup.
Update Caddyfile to handle new service. Add JWT_SECRET to 
GitHub Actions workflow. Enhance maintenance guidelines.