### PR TITLE
🐳 fix: update codigo-updater image name in compose file

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -22,7 +22,7 @@ services:
       start_period: 30s
 
   codigo-updater:
-    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/codigo-updater:latest"
+    image: "{{ CONTAINER_REGISTRY_URL }}/codigo/container-updater:latest"
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
Change the image name for the 'codigo-updater' service in the 
docker-compose configuration. This change ensures that the service 
uses the correct container name 'container-updater' as per the 
latest naming convention, improving clarity and consistency in 
the deployment environment.