### PR TITLE
✨ fix: update caddy_net network configuration

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -84,6 +84,8 @@ services:
 networks:
   caddy_net:
     external: true
+    name: caddy_net
+    attachable: true
 
 configs:
   caddyfile:


### PR DESCRIPTION
Add name and attachable properties to the caddy_net network in
the docker-compose file. This improves network management and
ensures compatibility with external services.