### PR TITLE
✨ refactor: rename codigo-updater to container-updater  

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -21,7 +21,7 @@ services:
       retries: 3
       start_period: 30s
 
-  codigo-updater:
+  container-updater:
     image: "{{ CONTAINER_REGISTRY_URL }}/codigo/container-updater:latest"
     deploy:
       replicas: 1


### PR DESCRIPTION
Renames the service `codigo-updater` to `container-updater` in  
the docker-compose configuration for clarity and consistency. This  
improves readability and aligns the service name with its functionality.