### PR TITLE
🚚 refactor: update Caddy configuration and remove redundant network settings

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -21,7 +21,7 @@ services:
       retries: 3
       start_period: 30s
 
-  container-updater:
+  container_updater:
     image: "{{ CONTAINER_REGISTRY_URL }}/codigo/container-updater:latest"
     deploy:
       replicas: 1
@@ -84,8 +84,6 @@ services:
 networks:
   caddy_net:
     external: true
-    name: caddy_net
-    attachable: true
 
 configs:
   caddyfile:

--- a/tooling/data/caddy/Caddyfile
+++ b/tooling/data/caddy/Caddyfile
@@ -53,9 +53,9 @@
 		}
 	}
 
-	@codigo_updater host updater.codigo.sh updater.maumercado.com
-	handle @codigo_updater {
-		reverse_proxy codigo-updater:3000 {
+	@container_updater host updater.codigo.sh updater.maumercado.com
+	handle @container_updater {
+		reverse_proxy container-updater:3000 {
 			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
 			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
 			header_up X-Forwarded-Host {http.request.host}


### PR DESCRIPTION
Remove unnecessary fields from the `docker-compose.tooling.yaml` file and 
rename the updater block in the `Caddyfile` to improve clarity. The 
changes streamline the network configuration while enhancing 
readability of the reverse proxy settings.