### PR TITLE
✨ chore: rename container updater to container-updater

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -21,7 +21,7 @@ services:
       retries: 3
       start_period: 30s
 
-  container_updater:
+  container-updater:
     image: "{{ CONTAINER_REGISTRY_URL }}/codigo/container-updater:latest"
     deploy:
       replicas: 1
@@ -31,6 +31,8 @@ services:
       JWT_SECRET: "{{ JWT_SECRET }}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "3000"
     networks:
       - caddy_net
 

--- a/tooling/data/caddy/Caddyfile
+++ b/tooling/data/caddy/Caddyfile
@@ -53,8 +53,8 @@
 		}
 	}
 
-	@container_updater host updater.codigo.sh updater.maumercado.com
-	handle @container_updater {
+	@container-updater host updater.codigo.sh updater.maumercado.com
+	handle @container-updater {
 		reverse_proxy container-updater:3000 {
 			header_up X-Forwarded-For {http.request.header.CF-Connecting-IP}
 			header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}


### PR DESCRIPTION
Updates the Caddyfile and Docker Compose configuration
to ensure consistency in naming. The `container_updater` 
is renamed to `container-updater` for clarity and 
adherence to naming conventions. Additionally, the 
Docker Compose file now exposes port 3000 for the 
container-updater service, enabling access to its API.