### PR TITLE
🎨 feat: enable privileged mode for container-updater service

### DIFF
--- a/docker-compose.tooling.yaml
+++ b/docker-compose.tooling.yaml
@@ -23,6 +23,7 @@ services:
 
   container-updater:
     image: "{{ CONTAINER_REGISTRY_URL }}/codigo/container-updater:latest"
+    privileged: true
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
Add the `privileged` option to the `container-updater` service in
the `docker-compose.tooling.yaml` file. This change allows the
service to run with elevated privileges, which is necessary for
certain operations that require direct access to the host system.