### PR TITLE
✨ chore: migrate semantic release to generate-docs job

### DIFF
--- a/.github/workflows/deploy-infrastructure.yaml
+++ b/.github/workflows/deploy-infrastructure.yaml
@@ -13,30 +13,7 @@ env:
   CLOUDFLARE_TUNNEL_SECRET: ${{ secrets.CLOUDFLARE_TUNNEL_SECRET }}
 
 jobs:
-  semantic-release:
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-    name: 'Semantic Release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
-        with:
-          semantic_version: 24.1.2
-          extra_plugins: |
-            @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
-            @semantic-release/changelog
-            @semantic-release/npm
-            @semantic-release/git
-        env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
-
   deploy:
-    needs: semantic-release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -1,0 +1,28 @@
+name: Generate Docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  semantic-release:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    name: 'Semantic Release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 24.1.2
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/changelog
+            @semantic-release/npm
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}


### PR DESCRIPTION
Remove semantic release from the deploy workflow and add it to the newly 
created generate-docs workflow. This change centralizes the semantic 
release process for documentation generation, ensuring consistency 
and clearer separation of concerns in the CI/CD pipeline.