### PR TITLE
🎉 chore: mark package as private in package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/node": "22.7.5",
     "typescript": "^5.6.3"
   },
+  "private": true,
   "release": {
     "branches": [
       "main"


### PR DESCRIPTION
Sets the "private" attribute to true in package.json to prevent 
accidental publication to the npm registry. This change ensures 
the package remains internal and is not published publicly.